### PR TITLE
Check PHP 7.3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ services:
 
 php:
   - 7.1
+  - 7.3
 
 env:
   - DB=mysql SYMFONY_ENV=travis


### PR DESCRIPTION
Lisan PHP 7.3 kontrolli Travisesse. Test keskkond juba on 7.3 peale lülitatud. Järgmise releasiga siis läheb lives ka PHP 7.3